### PR TITLE
Publish 1.1.1

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.1.0: QmNiFRHdeJgN9svSGkEtmhd5sGvv3suSKZ1sRkLqoCzL76
+1.1.1: QmU4WaTPrmDe2RcCTnLdWkXP6zV12qWbhBNfVtmN1ufHQ8

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmREK4tFmkEmrGgYU5cupeRVh71kLAkfjWcRq3krVUWWRq",
+      "hash": "QmeJcz1smiskcJbPRTWpzqnLpD2vYqkNiGHVrckaaWHCLv",
       "name": "go-reuseport",
-      "version": "0.1.4"
+      "version": "0.1.5"
     },
     {
       "author": "whyrusleeping",
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-tcp-transport",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.1.0"
+  "version": "1.1.1"
 }
 


### PR DESCRIPTION
Includes small fix to go-reuseport that disables logging of EINTR error which is created during normal operation.