### PR TITLE
update go-reuseport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: go
 
 go:
-    - 1.8
+    - 1.9
 
 install: true
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmS4L8WB9RLZLu9YbS19cHJVjQnuvTyGaGKs75DtmX4Jyo",
+      "hash": "QmQMdVT3PHEhMbdkANAqjpEmyUpVZEEzZyougpCSYqcjre",
       "name": "go-reuseport",
-      "version": "0.1.7"
+      "version": "0.1.9"
     },
     {
       "author": "whyrusleeping",

--- a/reuseport.go
+++ b/reuseport.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"syscall"
 
-	reuseport "github.com/jbenet/go-reuseport"
+	reuseport "github.com/libp2p/go-reuseport"
 )
 
 // envReuseport is the env variable name used to turn off reuse port.

--- a/tcp.go
+++ b/tcp.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	logging "github.com/ipfs/go-log"
-	reuseport "github.com/jbenet/go-reuseport"
+	reuseport "github.com/libp2p/go-reuseport"
 	tpt "github.com/libp2p/go-libp2p-transport"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"


### PR DESCRIPTION
1. Migrate to libp2p repo.
2. Pull in fixes for edge platforms. Related: use `x/sys` instead of `syscall` when possible.
3. Pull in less complicated and slightly faster dial logic.