### PR TITLE
Deprecate IPFS_REUSEPORT, use LIBP2P_TCP_REUSEPORT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 language: go
 
 go:
-    - 1.9.x
+    - 1.11.x
 
 install:
   - make deps

--- a/reuseport.go
+++ b/reuseport.go
@@ -9,7 +9,8 @@ import (
 
 // envReuseport is the env variable name used to turn off reuse port.
 // It default to true.
-const envReuseport = "IPFS_REUSEPORT"
+const envReuseport = "LIBP2P_TCP_REUSEPORT"
+const deprecatedEnvReuseport = "IPFS_REUSEPORT"
 
 // envReuseportVal stores the value of envReuseport. defaults to true.
 var envReuseportVal = true
@@ -18,7 +19,15 @@ func init() {
 	v := strings.ToLower(os.Getenv(envReuseport))
 	if v == "false" || v == "f" || v == "0" {
 		envReuseportVal = false
-		log.Infof("REUSEPORT disabled (IPFS_REUSEPORT=%s)", v)
+		log.Infof("REUSEPORT disabled (LIBP2P_TCP_REUSEPORT=%s)", v)
+	}
+	v, exist := os.LookupEnv(deprecatedEnvReuseport)
+	if exist {
+		log.Warning("IPFS_REUSEPORT is deprecated, use LIBP2P_TCP_REUSEPORT instead")
+		if v == "false" || v == "f" || v == "0" {
+			envReuseportVal = false
+			log.Infof("REUSEPORT disabled (IPFS_REUSEPORT=%s)", v)
+		}
 	}
 }
 
@@ -26,7 +35,7 @@ func init() {
 // is here because we want to be able to turn reuseport on and off selectively.
 // For now we use an ENV variable, as this handles our pressing need:
 //
-//   IPFS_REUSEPORT=false ipfs daemon
+//   LIBP2P_TCP_REUSEPORT=false ipfs daemon
 //
 // If this becomes a sought after feature, we could add this to the config.
 // In the end, reuseport is a stop-gap.


### PR DESCRIPTION
Fix https://github.com/libp2p/go-tcp-transport/issues/26