### PR TITLE
add bandwidth-related metrics (for Linux and OSX)

### DIFF
--- a/metrics_darwin.go
+++ b/metrics_darwin.go
@@ -1,0 +1,15 @@
+//+build darwin
+
+package tcp
+
+import "github.com/mikioh/tcpinfo"
+
+const (
+	hasSegmentCounter = true
+	hasByteCounter    = true
+)
+
+func getSegmentsSent(info *tcpinfo.Info) uint64 { return info.Sys.SegsSent }
+func getSegmentsRcvd(info *tcpinfo.Info) uint64 { return info.Sys.SegsReceived }
+func getBytesSent(info *tcpinfo.Info) uint64    { return info.Sys.BytesSent }
+func getBytesRcvd(info *tcpinfo.Info) uint64    { return info.Sys.BytesReceived }

--- a/metrics_general.go
+++ b/metrics_general.go
@@ -1,0 +1,15 @@
+//+build !linux,!darwin
+
+package tcp
+
+import "github.com/mikioh/tcpinfo"
+
+const (
+	hasSegmentCounter = false
+	hasByteCounter    = false
+)
+
+func getSegmentsSent(info *tcpinfo.Info) uint64 { return 0 }
+func getSegmentsRcvd(info *tcpinfo.Info) uint64 { return 0 }
+func getBytesSent(info *tcpinfo.Info) uint64    { return 0 }
+func getBytesRcvd(info *tcpinfo.Info) uint64    { return 0 }

--- a/metrics_linux.go
+++ b/metrics_linux.go
@@ -1,0 +1,15 @@
+//+build linux
+
+package tcp
+
+import "github.com/mikioh/tcpinfo"
+
+const (
+	hasSegmentCounter = true
+	hasByteCounter    = false
+)
+
+func getSegmentsSent(info *tcpinfo.Info) uint64 { return uint64(info.Sys.SegsOut) }
+func getSegmentsRcvd(info *tcpinfo.Info) uint64 { return uint64(info.Sys.SegsIn) }
+func getBytesSent(info *tcpinfo.Info) uint64    { return 0 }
+func getBytesRcvd(info *tcpinfo.Info) uint64    { return 0 }


### PR DESCRIPTION
Surprisingly, we only have access to the number of bytes sent / received on OSX, there's no counter for that on Linux: https://github.com/mikioh/tcpinfo/blob/30a79bb1804bc47fa7fe29928c9109f368792a9e/sys_linux.go#L45-L69