### PR TITLE
Skip SetKeepAlivePeriod call on OpenBSD

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -3,6 +3,7 @@ package tcp
 import (
 	"context"
 	"net"
+	"runtime"
 	"time"
 
 	logging "github.com/ipfs/go-log"
@@ -41,8 +42,11 @@ func tryKeepAlive(conn net.Conn, keepAlive bool) {
 		log.Errorf("Failed to enable TCP keepalive: %s", err)
 		return
 	}
-	if err := keepAliveConn.SetKeepAlivePeriod(keepAlivePeriod); err != nil {
-		log.Errorf("Failed set keepalive period: %s", err)
+
+	if runtime.GOOS != "openbsd" {
+		if err := keepAliveConn.SetKeepAlivePeriod(keepAlivePeriod); err != nil {
+			log.Errorf("Failed set keepalive period: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
OpenBSD does not have a user-settable per-socket TCP keepalives. This changes
tryKeepAlive to skip attempting set it when on OpenBSD.

  https://github.com/golang/go/blob/master/src/net/tcpsockopt_openbsd.go#L13-L14

This prevents thousands of `log.Errorf("Failed set keepalive period: %s",
err)`'s from happening.