### PR TITLE
disable metrics collection on Windows

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package tcp
 
 import (
@@ -248,6 +251,10 @@ func (c *tracingConn) getTCPInfo() (*tcpinfo.Info, error) {
 
 type tracingListener struct {
 	manet.Listener
+}
+
+func newTracingListener(l manet.Listener) *tracingListener {
+	return &tracingListener{Listener: l}
 }
 
 func (l *tracingListener) Accept() (manet.Conn, error) {

--- a/metrics_general.go
+++ b/metrics_general.go
@@ -1,5 +1,5 @@
-//go:build !linux && !darwin
-// +build !linux,!darwin
+//go:build !linux && !darwin && !windows
+// +build !linux,!darwin,!windows
 
 package tcp
 

--- a/metrics_windows.go
+++ b/metrics_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+// +build windows
+
+package tcp
+
+import manet "github.com/multiformats/go-multiaddr/net"
+
+func newTracingConn(c manet.Conn, _ bool) (manet.Conn, error) { return c, nil }
+func newTracingListener(l manet.Listener) manet.Listener      { return l }

--- a/tcp.go
+++ b/tcp.go
@@ -172,7 +172,7 @@ func (t *TcpTransport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	list = &tracingListener{&tcpListener{list, 0}}
+	list = newTracingListener(&tcpListener{list, 0})
 	return t.Upgrader.UpgradeListener(t, list), nil
 }
 


### PR DESCRIPTION
Fixes #91.

We could collect metrics like the connection duration on Windows, but I don't care enough about that OS to make that happen.