### PR TITLE
simplify dial timeout context

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -121,12 +121,9 @@ func (t *TcpTransport) CanDial(addr ma.Multiaddr) bool {
 func (t *TcpTransport) maDial(ctx context.Context, raddr ma.Multiaddr) (manet.Conn, error) {
 	// Apply the deadline iff applicable
 	if t.ConnectTimeout > 0 {
-		deadline := time.Now().Add(t.ConnectTimeout)
-		if d, ok := ctx.Deadline(); !ok || deadline.Before(d) {
-			var cancel func()
-			ctx, cancel = context.WithDeadline(ctx, deadline)
-			defer cancel()
-		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, t.ConnectTimeout)
+		defer cancel()
 	}
 
 	if t.UseReuseport() {


### PR DESCRIPTION
From the documentation:
> WithDeadline returns a copy of the parent context with the deadline adjusted to be no later than d. If the parent's deadline is already earlier than d, WithDeadline(parent, d) is semantically equivalent to parent.