### PR TITLE
deprecate the use of LIBP2P_TCP_REUSEPORT

### DIFF
--- a/reuseport.go
+++ b/reuseport.go
@@ -8,7 +8,8 @@ import (
 )
 
 // envReuseport is the env variable name used to turn off reuse port.
-// It default to true.
+// It defaults to true.
+// Deprecated: use the constructor option DisableReuseport instead.
 const envReuseport = "LIBP2P_TCP_REUSEPORT"
 
 // envReuseportVal stores the value of envReuseport. defaults to true.
@@ -16,6 +17,9 @@ var envReuseportVal = true
 
 func init() {
 	v := strings.ToLower(os.Getenv(envReuseport))
+	if len(v) > 0 {
+		log.Warn("LIBP2P_TCP_REUSEPORT is deprecated. Use the DisableReuseport constructor option instead.")
+	}
 	if v == "false" || v == "f" || v == "0" {
 		envReuseportVal = false
 		log.Infof("REUSEPORT disabled (LIBP2P_TCP_REUSEPORT=%s)", v)

--- a/reuseport.go
+++ b/reuseport.go
@@ -10,7 +10,6 @@ import (
 // envReuseport is the env variable name used to turn off reuse port.
 // It default to true.
 const envReuseport = "LIBP2P_TCP_REUSEPORT"
-const deprecatedEnvReuseport = "IPFS_REUSEPORT"
 
 // envReuseportVal stores the value of envReuseport. defaults to true.
 var envReuseportVal = true
@@ -21,17 +20,9 @@ func init() {
 		envReuseportVal = false
 		log.Infof("REUSEPORT disabled (LIBP2P_TCP_REUSEPORT=%s)", v)
 	}
-	v, exist := os.LookupEnv(deprecatedEnvReuseport)
-	if exist {
-		log.Warn("IPFS_REUSEPORT is deprecated, use LIBP2P_TCP_REUSEPORT instead")
-		if v == "false" || v == "f" || v == "0" {
-			envReuseportVal = false
-			log.Infof("REUSEPORT disabled (IPFS_REUSEPORT=%s)", v)
-		}
-	}
 }
 
-// reuseportIsAvailable returns whether reuseport is available to be used. This
+// ReuseportIsAvailable returns whether reuseport is available to be used. This
 // is here because we want to be able to turn reuseport on and off selectively.
 // For now we use an ENV variable, as this handles our pressing need:
 //


### PR DESCRIPTION
Now that we have constructor options (and make them actually usable with https://github.com/libp2p/go-libp2p/pull/1205), we don't need to control reuseport using environment variables any more. Just pass `tcp.DisableReuseport()` to the transport constructor instead.

This PR:
1. removes support for the ancient IPFS_REUSEPORT option, which was deprecated in 2018 (#27)
2. deprecates the LIBP2P_TCP_REUSEPORT, displaying a warning when this env is set