### PR TITLE
remove the deprecated IPFS_REUSEPORT command line flag

### DIFF
--- a/reuseport.go
+++ b/reuseport.go
@@ -10,7 +10,6 @@ import (
 // envReuseport is the env variable name used to turn off reuse port.
 // It default to true.
 const envReuseport = "LIBP2P_TCP_REUSEPORT"
-const deprecatedEnvReuseport = "IPFS_REUSEPORT"
 
 // envReuseportVal stores the value of envReuseport. defaults to true.
 var envReuseportVal = true
@@ -21,17 +20,9 @@ func init() {
 		envReuseportVal = false
 		log.Infof("REUSEPORT disabled (LIBP2P_TCP_REUSEPORT=%s)", v)
 	}
-	v, exist := os.LookupEnv(deprecatedEnvReuseport)
-	if exist {
-		log.Warn("IPFS_REUSEPORT is deprecated, use LIBP2P_TCP_REUSEPORT instead")
-		if v == "false" || v == "f" || v == "0" {
-			envReuseportVal = false
-			log.Infof("REUSEPORT disabled (IPFS_REUSEPORT=%s)", v)
-		}
-	}
 }
 
-// reuseportIsAvailable returns whether reuseport is available to be used. This
+// ReuseportIsAvailable returns whether reuseport is available to be used. This
 // is here because we want to be able to turn reuseport on and off selectively.
 // For now we use an ENV variable, as this handles our pressing need:
 //


### PR DESCRIPTION
This flag has been deprecated since 2018.