### PR TITLE
use the transport.Upgrader interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,16 @@ go 1.16
 require (
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/libp2p/go-conn-security-multistream v0.3.0
-	github.com/libp2p/go-libp2p-core v0.10.0
+	github.com/libp2p/go-libp2p-core v0.13.1-0.20220104083644-a3dd401efe36
 	github.com/libp2p/go-libp2p-mplex v0.4.1
 	github.com/libp2p/go-libp2p-testing v0.5.0
-	github.com/libp2p/go-libp2p-transport-upgrader v0.5.0
+	github.com/libp2p/go-libp2p-transport-upgrader v0.6.1-0.20220104084635-5fc0a74b41f0
 	github.com/libp2p/go-netroute v0.1.5 // indirect
 	github.com/libp2p/go-reuseport v0.1.0
 	github.com/libp2p/go-reuseport-transport v0.1.0
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b
-	github.com/multiformats/go-multiaddr v0.4.0
+	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/multiformats/go-multiaddr-fmt v0.1.0
 	github.com/multiformats/go-multihash v0.0.15 // indirect
 	github.com/prometheus/client_golang v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,9 @@ github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS
 github.com/libp2p/go-libp2p-core v0.3.0/go.mod h1:ACp3DmS3/N64c2jDzcV429ukDpicbL6+TrrxANBjPGw=
 github.com/libp2p/go-libp2p-core v0.5.0/go.mod h1:49XGI+kc38oGVwqSBhDEwytaAxgZasHhFfQKibzTls0=
 github.com/libp2p/go-libp2p-core v0.8.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
-github.com/libp2p/go-libp2p-core v0.10.0 h1:jFy7v5Muq58GTeYkPhGzIH8Qq4BFfziqc0ixPd/pP9k=
 github.com/libp2p/go-libp2p-core v0.10.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
+github.com/libp2p/go-libp2p-core v0.13.1-0.20220104083644-a3dd401efe36 h1:b/pMmgc5EV+dqSc+MjkX5xPa1nV6EKiOb0L0XT03Lic=
+github.com/libp2p/go-libp2p-core v0.13.1-0.20220104083644-a3dd401efe36/go.mod h1:KlkHsZ0nKerWsXLZJm3LfFQwusI5k3iN4BgtYTE4IYE=
 github.com/libp2p/go-libp2p-mplex v0.4.1 h1:/pyhkP1nLwjG3OM+VuaNJkQT/Pqq73WzB3aDN3Fx1sc=
 github.com/libp2p/go-libp2p-mplex v0.4.1/go.mod h1:cmy+3GfqfM1PceHTLL7zQzAAYaryDu6iPSC+CIb094g=
 github.com/libp2p/go-libp2p-pnet v0.2.0 h1:J6htxttBipJujEjz1y0a5+eYoiPcFHhSYHH6na5f0/k=
@@ -214,8 +215,8 @@ github.com/libp2p/go-libp2p-testing v0.1.2-0.20200422005655-8775583591d8/go.mod 
 github.com/libp2p/go-libp2p-testing v0.4.0/go.mod h1:Q+PFXYoiYFN5CAEG2w3gLPEzotlKsNSbKQ/lImlOWF0=
 github.com/libp2p/go-libp2p-testing v0.5.0 h1:bTjC29TTQ/ODq0ld3+0KLq3irdA5cAH3OMbRi0/QsvE=
 github.com/libp2p/go-libp2p-testing v0.5.0/go.mod h1:QBk8fqIL1XNcno/l3/hhaIEn4aLRijpYOR+zVjjlh+A=
-github.com/libp2p/go-libp2p-transport-upgrader v0.5.0 h1:7SDl3O2+AYOgfE40Mis83ClpfGNkNA6m4FwhbOHs+iI=
-github.com/libp2p/go-libp2p-transport-upgrader v0.5.0/go.mod h1:Rc+XODlB3yce7dvFV4q/RmyJGsFcCZRkeZMu/Zdg0mo=
+github.com/libp2p/go-libp2p-transport-upgrader v0.6.1-0.20220104084635-5fc0a74b41f0 h1:eD/QJCpcImYOUl6MdBuxMByVaEe5VMm463zJG6oUg9o=
+github.com/libp2p/go-libp2p-transport-upgrader v0.6.1-0.20220104084635-5fc0a74b41f0/go.mod h1:ByIyNe8asQhgcyIHetb4f+UgV+hDrA8pQ3L/TgNs+RI=
 github.com/libp2p/go-maddr-filter v0.1.0/go.mod h1:VzZhTXkMucEGGEOSKddrwGiOv0tUhgnKqNEmIAz/bPU=
 github.com/libp2p/go-mplex v0.3.0 h1:U1T+vmCYJaEoDJPV1aq31N56hS+lJgb397GsylNSgrU=
 github.com/libp2p/go-mplex v0.3.0/go.mod h1:0Oy/A9PQlwBytDRp4wSkFnzHYDKcpLot35JQ6msjvYQ=
@@ -289,9 +290,9 @@ github.com/multiformats/go-multiaddr v0.2.1/go.mod h1:s/Apk6IyxfvMjDafnhJgJ3/46z
 github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u0xW5UouOmQQrn6a3Y=
 github.com/multiformats/go-multiaddr v0.3.0/go.mod h1:dF9kph9wfJ+3VLAaeBqo9Of8x4fJxp6ggJGteB8HQTI=
 github.com/multiformats/go-multiaddr v0.3.1/go.mod h1:uPbspcUPd5AfaP6ql3ujFY+QWzmBD8uLLL4bXW0XfGc=
-github.com/multiformats/go-multiaddr v0.3.3/go.mod h1:lCKNGP1EQ1eZ35Za2wlqnabm9xQkib3fyB+nZXHLag0=
-github.com/multiformats/go-multiaddr v0.4.0 h1:hL/K4ZJhJ5PTw3nwylq9lGU5yArzcAroZmex1ghSEkQ=
 github.com/multiformats/go-multiaddr v0.4.0/go.mod h1:YcpyLH8ZPudLxQlemYBPhSm0/oCXAT8Z4mzFpyoPyRc=
+github.com/multiformats/go-multiaddr v0.4.1 h1:Pq37uLx3hsyNlTDir7FZyU8+cFCTqd5y1KiM2IzOutI=
+github.com/multiformats/go-multiaddr v0.4.1/go.mod h1:3afI9HfVW8csiF8UZqtpYRiDyew8pRX7qLIGHu9FLuM=
 github.com/multiformats/go-multiaddr-fmt v0.1.0 h1:WLEFClPycPkp4fnIzoFoV9FVd49/eQsuaL3/CWe167E=
 github.com/multiformats/go-multiaddr-fmt v0.1.0/go.mod h1:hGtDIW4PU4BqJ50gW2quDuPVjyWNZxToGUh/HwTZYJo=
 github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5rnK7YaOIEOPVDI9tsJbEA=

--- a/tcp.go
+++ b/tcp.go
@@ -12,7 +12,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/transport"
 
-	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
 	rtpt "github.com/libp2p/go-reuseport-transport"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -106,7 +105,7 @@ func WithConnectionTimeout(d time.Duration) Option {
 type TcpTransport struct {
 	// Connection upgrader for upgrading insecure stream connections to
 	// secure multiplex connections.
-	Upgrader *tptu.Upgrader
+	Upgrader transport.Upgrader
 
 	// Explicitly disable reuseport.
 	disableReuseport bool
@@ -121,7 +120,7 @@ var _ transport.Transport = &TcpTransport{}
 
 // NewTCPTransport creates a tcp transport object that tracks dialers and listeners
 // created. It represents an entire TCP stack (though it might not necessarily be).
-func NewTCPTransport(upgrader *tptu.Upgrader, opts ...Option) (*TcpTransport, error) {
+func NewTCPTransport(upgrader transport.Upgrader, opts ...Option) (*TcpTransport, error) {
 	tr := &TcpTransport{
 		Upgrader:       upgrader,
 		connectTimeout: defaultConnectTimeout, // can be set by using the WithConnectionTimeout option

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -3,11 +3,13 @@ package tcp
 import (
 	"testing"
 
-	csms "github.com/libp2p/go-conn-security-multistream"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"
 	"github.com/libp2p/go-libp2p-core/sec/insecure"
+	"github.com/libp2p/go-libp2p-core/transport"
+
+	csms "github.com/libp2p/go-conn-security-multistream"
 	mplex "github.com/libp2p/go-libp2p-mplex"
 	ttransport "github.com/libp2p/go-libp2p-testing/suites/transport"
 	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
@@ -22,15 +24,13 @@ func TestTcpTransport(t *testing.T) {
 		peerA, ia := makeInsecureMuxer(t)
 		_, ib := makeInsecureMuxer(t)
 
-		ta, err := NewTCPTransport(&tptu.Upgrader{
-			Secure: ia,
-			Muxer:  new(mplex.Transport),
-		})
+		ua, err := tptu.New(ia, new(mplex.Transport))
 		require.NoError(t, err)
-		tb, err := NewTCPTransport(&tptu.Upgrader{
-			Secure: ib,
-			Muxer:  new(mplex.Transport),
-		})
+		ta, err := NewTCPTransport(ua)
+		require.NoError(t, err)
+		ub, err := tptu.New(ib, new(mplex.Transport))
+		require.NoError(t, err)
+		tb, err := NewTCPTransport(ub)
 		require.NoError(t, err)
 
 		zero := "/ip4/127.0.0.1/tcp/0"
@@ -46,11 +46,8 @@ func TestTcpTransportCantDialDNS(t *testing.T) {
 		dnsa, err := ma.NewMultiaddr("/dns4/example.com/tcp/1234")
 		require.NoError(t, err)
 
-		_, sm := makeInsecureMuxer(t)
-		tpt, err := NewTCPTransport(&tptu.Upgrader{
-			Secure: sm,
-			Muxer:  new(mplex.Transport),
-		})
+		var u transport.Upgrader
+		tpt, err := NewTCPTransport(u)
 		require.NoError(t, err)
 
 		if tpt.CanDial(dnsa) {
@@ -67,15 +64,12 @@ func TestTcpTransportCantListenUtp(t *testing.T) {
 		utpa, err := ma.NewMultiaddr("/ip4/127.0.0.1/udp/0/utp")
 		require.NoError(t, err)
 
-		_, sm := makeInsecureMuxer(t)
-		tpt, err := NewTCPTransport(&tptu.Upgrader{
-			Secure: sm,
-			Muxer:  new(mplex.Transport),
-		})
+		var u transport.Upgrader
+		tpt, err := NewTCPTransport(u)
 		require.NoError(t, err)
 
 		_, err = tpt.Listen(utpa)
-		require.Error(t, err, "shouldnt be able to listen on utp addr with tcp transport")
+		require.Error(t, err, "shouldn't be able to listen on utp addr with tcp transport")
 
 		envReuseportVal = false
 	}


### PR DESCRIPTION
If we had a decent mock stream muxer implementation, we could get rid of quite a few packages in the dependency graph here:
* transport upgrader
* mplex
* go-conn-security-multistream (?)

I'll leave this as an exercise for a later point.