### PR TITLE
re-add NewTCPTransport method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/libp2p/go-tcp-transport
 
 go 1.17
 
-require github.com/libp2p/go-libp2p v0.20.0
+require (
+	github.com/libp2p/go-libp2p v0.20.0
+	github.com/libp2p/go-libp2p-core v0.16.1
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -18,7 +21,6 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect
-	github.com/libp2p/go-libp2p-core v0.16.1 // indirect
 	github.com/libp2p/go-netroute v0.2.0 // indirect
 	github.com/libp2p/go-openssl v0.0.7 // indirect
 	github.com/libp2p/go-reuseport v0.2.0 // indirect

--- a/tcp.go
+++ b/tcp.go
@@ -4,6 +4,9 @@ package tcp
 import (
 	"time"
 
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/transport"
+
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 )
 
@@ -23,3 +26,10 @@ func WithConnectionTimeout(d time.Duration) Option {
 // TcpTransport is the TCP transport.
 // Deprecated: use github.com/libp2p/go-libp2p/p2p/transport/tcp.TcpTransport instead.
 type TcpTransport = tcp.TcpTransport
+
+// NewTCPTransport creates a tcp transport object that tracks dialers and listeners
+// created. It represents an entire TCP stack (though it might not necessarily be).
+// Deprecated: use github.com/libp2p/go-libp2p/p2p/transport/tcp.NewTCPTransport instead.
+func NewTCPTransport(upgrader transport.Upgrader, rcmgr network.ResourceManager, opts ...Option) (*TcpTransport, error) {
+	return tcp.NewTCPTransport(upgrader, rcmgr, opts...)
+}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.0"
+  "version": "v0.6.1"
 }


### PR DESCRIPTION
Apparently I deleted this function when I deprecated this repo.